### PR TITLE
Overhaul the plugin architecture, adding locks and debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,14 @@
 			"license": "Actionforge Community License v1",
 			"dependencies": {
 				"@octokit/rest": "^20.0.2",
-				"js-yaml": "^4.1.0"
+				"async-lock": "^1.4.1",
+				"js-yaml": "^4.1.0",
+				"lodash.debounce": "^4.0.8"
 			},
 			"devDependencies": {
+				"@types/async-lock": "^1.4.2",
 				"@types/js-yaml": "^4.0.9",
+				"@types/lodash.debounce": "^4.0.9",
 				"@types/node": "^16.18.34",
 				"@types/vscode": "^1.73.0",
 				"@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -285,6 +289,12 @@
 				"@octokit/openapi-types": "^19.0.2"
 			}
 		},
+		"node_modules/@types/async-lock": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+			"integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
+			"dev": true
+		},
 		"node_modules/@types/js-yaml": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -296,6 +306,21 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
 			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.202",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+			"integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+			"dev": true
+		},
+		"node_modules/@types/lodash.debounce": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+			"integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/lodash": "*"
+			}
 		},
 		"node_modules/@types/node": {
 			"version": "16.18.34",
@@ -652,6 +677,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1366,6 +1396,11 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2051,6 +2086,12 @@
 				"@octokit/openapi-types": "^19.0.2"
 			}
 		},
+		"@types/async-lock": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+			"integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
+			"dev": true
+		},
 		"@types/js-yaml": {
 			"version": "4.0.9",
 			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -2062,6 +2103,21 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
 			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
+		},
+		"@types/lodash": {
+			"version": "4.14.202",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+			"integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
+			"dev": true
+		},
+		"@types/lodash.debounce": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+			"integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+			"dev": true,
+			"requires": {
+				"@types/lodash": "*"
+			}
 		},
 		"@types/node": {
 			"version": "16.18.34",
@@ -2274,6 +2330,11 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
+		},
+		"async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.2",
@@ -2821,6 +2882,11 @@
 			"requires": {
 				"p-locate": "^5.0.0"
 			}
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
 		},
 		"lodash.merge": {
 			"version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
 		"watch": "tsc -w -p ./"
 	},
 	"devDependencies": {
+		"@types/async-lock": "^1.4.2",
 		"@types/js-yaml": "^4.0.9",
+		"@types/lodash.debounce": "^4.0.9",
 		"@types/node": "^16.18.34",
 		"@types/vscode": "^1.73.0",
 		"@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -86,6 +88,8 @@
 	},
 	"dependencies": {
 		"@octokit/rest": "^20.0.2",
-		"js-yaml": "^4.1.0"
+		"async-lock": "^1.4.1",
+		"js-yaml": "^4.1.0",
+		"lodash.debounce": "^4.0.8"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"sourceMap": true,
 		"strict": true,
 		"rootDir": "src",
+		"esModuleInterop": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
This PR fixes a couple of bugs related to buggy UI refreshs, incorreect read-only modes etc.

The architecture of VS Code Extensions is async, making it difficult at the moment to support multiple views. Therefore this commit removes the option to have the same graph open in multiple views (other text editors or another view). Whenever a new view is created, either the old view will be revealed, or closed and the new view is displayed. Comment in line #46 adds a little bit more context to this decision
