### PR TITLE
Add support for older VS Code versions

### DIFF
--- a/.github/workflows/graphs/workflow.yml
+++ b/.github/workflows/graphs/workflow.yml
@@ -104,8 +104,7 @@ nodes:
     inputs:
       script: |-
         npm run vscode:prepublish
-        setopt no_nomatch
-        rm *.vsix
+        rm *.vsix 2>/dev/null || true
         npx vsce package
     settings:
       folded: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "actionforge",
-	"version": "0.6.20",
+	"version": "0.6.21",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "actionforge",
-			"version": "0.6.20",
+			"version": "0.6.21",
 			"license": "Actionforge Community License",
 			"dependencies": {
 				"@octokit/rest": "^20.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,26 +9,26 @@
 			"version": "0.6.21",
 			"license": "Actionforge Community License",
 			"dependencies": {
-				"@octokit/rest": "^20.0.2",
-				"async-lock": "^1.4.1",
-				"js-yaml": "^4.1.0",
-				"lodash.debounce": "^4.0.8"
+				"@octokit/rest": "20.0.2",
+				"async-lock": "1.4.1",
+				"js-yaml": "4.1.0",
+				"lodash.debounce": "4.0.8"
 			},
 			"devDependencies": {
-				"@types/async-lock": "^1.4.2",
-				"@types/js-yaml": "^4.0.9",
-				"@types/lodash.debounce": "^4.0.9",
+				"@types/async-lock": "1.4.2",
+				"@types/js-yaml": "4.0.9",
+				"@types/lodash.debounce": "4.0.9",
 				"@types/node": "20.10.6",
-				"@types/vscode": "^1.85.0",
-				"@typescript-eslint/eslint-plugin": "^6.16.0",
-				"@typescript-eslint/parser": "^6.16.0",
-				"esbuild": "^0.19.11",
-				"eslint": "^8.56.0",
-				"tslib": "^2.6.2",
-				"typescript": "^5.3.3"
+				"@types/vscode": "1.74.0",
+				"@typescript-eslint/eslint-plugin": "6.16.0",
+				"@typescript-eslint/parser": "6.16.0",
+				"esbuild": "0.19.11",
+				"eslint": "8.56.0",
+				"tslib": "2.6.2",
+				"typescript": "5.3.3"
 			},
 			"engines": {
-				"vscode": "^1.85.0"
+				"vscode": "^1.74.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -726,9 +726,9 @@
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
-			"version": "1.85.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
-			"integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -2630,9 +2630,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.85.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
-			"integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
+			"version": "1.74.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
+			"integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "actionforge",
 	"displayName": "Actionforge Graph Editor",
 	"description": "A visual editor for GitHub Actions workflows",
-	"version": "0.6.20",
+	"version": "0.6.21",
 	"publisher": "Actionforge",
 	"icon": "assets/icon.png",
 	"homepage": "https://www.actionforge.dev",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/actionforge/vscode-ext"
 	},
 	"engines": {
-		"vscode": "1.85.0"
+		"vscode": "^1.82.0"
 	},
 	"categories": [
 		"Visualization",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"url": "https://github.com/actionforge/vscode-ext"
 	},
 	"engines": {
-		"vscode": "^1.82.0"
+		"vscode": "^1.74.0"
 	},
 	"categories": [
 		"Visualization",
@@ -123,7 +123,7 @@
 		"@types/js-yaml": "4.0.9",
 		"@types/lodash.debounce": "4.0.9",
 		"@types/node": "20.10.6",
-		"@types/vscode": "1.85.0",
+		"@types/vscode": "1.74.0",
 		"@typescript-eslint/eslint-plugin": "6.16.0",
 		"@typescript-eslint/parser": "6.16.0",
 		"esbuild": "0.19.11",


### PR DESCRIPTION
This PR adds support for older VS Code Versions `v1.74.0` and up. The changes also contain a substitute for `setopt` as it might not always be available.