### PR TITLE
Use actionforge/action@v0.8.31 for new action graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
       name: My workflow
       steps:
         - name: Execute Action Graph
-          uses: actionforge/action@v0.4.35
+          uses: actionforge/action@v0.8.31
           with:
             graph_file: my-workflow.yml
 ```

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -246,7 +246,7 @@ jobs:
       name: My workflow
       steps:
         - name: Execute Action Graph
-          uses: actionforge/action@v0.4.35
+          uses: actionforge/action@v0.8.31
           with:
             graph_file: ${newName}`;
 


### PR DESCRIPTION
This PR bumps the version of `actionforge/action` to `v0.8.31`, the latest version of the actionforge GH action.