### PR TITLE
Hide toolbar-only commands from command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,20 @@
 			}
 		],
 		"menus": {
+			"commandPalette": [
+				{
+					"command": "actionforge.fit-to-canvas",
+					"when": "false"
+				},
+				{
+					"command": "actionforge.arrange-nodes",
+					"when": "false"
+				},
+				{
+					"command": "actionforge.switch-view",
+					"when": "false"
+				}
+			],
 			"editor/title": [
 				{
 					"command": "actionforge.switch-view",


### PR DESCRIPTION
It's pointless to allow users to invoke these commands from the command palette just to throw a dialog box saying that you can't do that.