### PR TITLE
Lock action version to improve security

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,6 +6,6 @@ jobs:
       name: My workflow
       steps:
         - name: Execute Action Graph
-          uses: actionforge/action@v0.8.30
+          uses: actionforge/action@919d415a6b6e22919f7e115cf594ae52ded95041  # v0.8.31
           with:
             graph_file: build-and-publish.yml

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
       name: My workflow
       steps:
         - name: Execute Action Graph
-          uses: actionforge/action@v0.8.31
+          uses: actionforge/action@919d415a6b6e22919f7e115cf594ae52ded95041  # v0.8.31
           with:
             graph_file: my-workflow.yml
 ```

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -249,7 +249,7 @@ jobs:
       name: My workflow
       steps:
         - name: Execute Action Graph
-          uses: actionforge/action@v0.8.31
+		  uses: actionforge/action@919d415a6b6e22919f7e115cf594ae52ded95041  # v0.8.31
           with:
             graph_file: ${newName}`;
 


### PR DESCRIPTION
This PR locks the action to [`919d415a6b6e22919f7e115cf594ae52ded95041`](https://github.com/actionforge/action/commit/919d415a6b6e22919f7e115cf594ae52ded95041) to improve security.